### PR TITLE
feat: re-export useLazyQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Drop-in replacements for [@apollo/client](https://github.com/apollographql/apoll
 - It improves performance by automatically reducing the size of queries sent to the server by stripping all the fields from them that are already in the cache. See [this guide on reduced queries](REDUCED_QUERIES.md) for more information.
 - It allows for smaller queries to be written by passing a data map to `useQuery`. See [this guide on data mapping](DATA_MAPPING.md) for more information.
 - It allows you to globally provide context data for all queries and mutations using a hook.
+- It allows you to omit the [`gql`](https://www.apollographql.com/docs/resources/graphql-glossary/#gql-function) wrapper function from all query strings.
 - It fixes a race condition causing cache updates with stale data when simultaneously performing mutations and poll requests.
 
 ## Installation
@@ -52,6 +53,10 @@ An object telling `useQuery` which parts of the response data should be mapped t
 #### - pagination
 
 *Experimental and WIP.*
+
+### useLazyQuery
+
+Re-export of [@apollo/client](https://www.apollographql.com/docs/react/api/react/hooks/#uselazyquery).
 
 ### useMutation
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,12 @@ Object.defineProperty(exports, "useQuery", {
     return _useQuery["default"];
   }
 });
+Object.defineProperty(exports, "useLazyQuery", {
+  enumerable: true,
+  get: function get() {
+    return _useLazyQuery["default"];
+  }
+});
 Object.defineProperty(exports, "useMutation", {
   enumerable: true,
   get: function get() {
@@ -43,6 +49,8 @@ Object.defineProperty(exports, "setGlobalContextHook", {
 });
 
 var _useQuery = _interopRequireDefault(require("./useQuery"));
+
+var _useLazyQuery = _interopRequireDefault(require("./useLazyQuery"));
 
 var _useMutation = _interopRequireDefault(require("./useMutation"));
 

--- a/lib/useLazyQuery.js
+++ b/lib/useLazyQuery.js
@@ -1,0 +1,16 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+
+var _client = require("@apollo/client");
+
+var _default = function _default(query) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  var queryAst = typeof query === 'string' ? (0, _client.gql)(query) : query;
+  return (0, _client.useLazyQuery)(queryAst, options);
+};
+
+exports["default"] = _default;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import useQuery from './useQuery';
+import useLazyQuery from './useLazyQuery';
 import useMutation from './useMutation';
 import useSubscription from './useSubscription';
 import combineResults from './combineResults';
@@ -7,6 +8,7 @@ import { setGlobalContextHook } from './globalContextHook';
 
 export {
     useQuery,
+    useLazyQuery,
     useMutation,
     useSubscription,
     combineResults,

--- a/src/useLazyQuery.js
+++ b/src/useLazyQuery.js
@@ -1,0 +1,6 @@
+import { gql, useLazyQuery } from '@apollo/client';
+
+export default (query, options = {}) => {
+    const queryAst = typeof query === 'string' ? gql(query) : query;
+    return useLazyQuery(queryAst, options);
+};


### PR DESCRIPTION
Adds a re-export of `useLazyQuery` from `@apollo/client` without caching functionalities. This can probably be improved upon, but it's beyond my knowledge to add this behavior.